### PR TITLE
Quote value of HOSTILE_CACHE_DIR environment variable

### DIFF
--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -11,7 +11,7 @@ process fetchHostileReference {
 
     script:
     """
-    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile"
+    export HOSTILE_CACHE_DIR='${params.store_dir}/hostile'
     hostile fetch --aligner bowtie2
 
     touch hostile.ok
@@ -68,7 +68,7 @@ process performHostFilter {
 
     script:
     """
-    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile/"
+    export HOSTILE_CACHE_DIR='${params.store_dir}/hostile/'
     hostile clean --fastq1 ${forward} --fastq2 ${reverse} --out-dir . --threads ${task.cpus}
     """
 }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -11,7 +11,7 @@ process fetchHostileReference {
 
     script:
     """
-    export HOSTILE_CACHE_DIR=${params.store_dir}/hostile/
+    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile/"
     hostile fetch --aligner bowtie2
 
     touch hostile.ok

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -11,7 +11,7 @@ process fetchHostileReference {
 
     script:
     """
-    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile/"
+    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile"
     hostile fetch --aligner bowtie2
 
     touch hostile.ok
@@ -68,7 +68,7 @@ process performHostFilter {
 
     script:
     """
-    export HOSTILE_CACHE_DIR=${params.store_dir}/hostile/
+    export HOSTILE_CACHE_DIR="${params.store_dir}/hostile/"
     hostile clean --fastq1 ${forward} --fastq2 ${reverse} --out-dir . --threads ${task.cpus}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   description = 'Epi2me compatible Nextflow pipeline for processing ARTIC tiling amplicon Illumina sequencing reads from monkeypox virus (MPXV) samples.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = '1.4.1'
+  version = '1.4.10'
   defaultBranch = 'main'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   description = 'Epi2me compatible Nextflow pipeline for processing ARTIC tiling amplicon Illumina sequencing reads from monkeypox virus (MPXV) samples.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = '1.4.10'
+  version = '1.4.2'
   defaultBranch = 'main'
 }
 


### PR DESCRIPTION
If `params.store_dir` contains a space, the `export HOSTILE_CACHE_DIR=${params.store_dir}/hostile/` line does not evaluate correctly. This can happen on Windows with WSL2 and Epi2Me Desktop if the Windows username contains a space.

This PR simply adds quotes around the two places where this environment variable is set up.